### PR TITLE
Fix so no longer need JSInterop exports and solve security blocking issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ local.properties
 *.idea
 .idea/
 pom.xml.releaseBackup
-release.properties
+release.properties.checkstyle
+.checkstyle

--- a/README.md
+++ b/README.md
@@ -21,22 +21,7 @@ Quick start
 
 2\. Add `<inherits name="io.github.freddyboucher.gwt.oauth2.OAuth2"/>` to your GWT module XML file.
 
-3\. Add the `generateJsInteropExports` compilation option to your project. 
-If you use the tbroyer's [Maven Plugin for GWT](https://tbroyer.github.io/gwt-maven-plugin/) it should look like:
-```xml
-<plugin>
-  <groupId>net.ltgt.gwt.maven</groupId>
-  <artifactId>gwt-maven-plugin</artifactId>
-  <configuration>
-    <compilerArgs>
-      <arg>-generateJsInteropExports</arg>
-    </compilerArgs>
-    <codeserverArgs>
-      <arg>-generateJsInteropExports</arg>
-    </codeserverArgs>
-  </configuration>
-</plugin>
-```
+3\. You do not need to add the `generateJsInteropExports` compilation option to your project.
 
 4\. Use it as follow:
 ```java
@@ -67,6 +52,8 @@ public class App implements EntryPoint {
 
 Release Notes
 -------------
+- 1.2
+    - Fix: Deal with issue that oauth window cannot access parent window custom JS by switching to window.postMessage.
 - 1.1
     - Fix: Avoid Google api.js name collision by renaming `oauth2` to `gwtOAuth2`
 - 1.0

--- a/gwt-oauth2/src/main/java/io/github/freddyboucher/gwt/oauth2/client/AuthImpl.java
+++ b/gwt-oauth2/src/main/java/io/github/freddyboucher/gwt/oauth2/client/AuthImpl.java
@@ -50,8 +50,7 @@ class AuthImpl extends Auth {
       MessageEvent messageEvent = (MessageEvent) evt;
       String data = String.valueOf(messageEvent.data);
       String origin = messageEvent.origin;
-      DomGlobal.console.info(evt);
-      DomGlobal.console.info(data);
+      finish(data);
       DomGlobal.console.info(origin);
     };
     DomGlobal.window.addEventListener("message", listener);

--- a/gwt-oauth2/src/main/java/io/github/freddyboucher/gwt/oauth2/client/AuthImpl.java
+++ b/gwt-oauth2/src/main/java/io/github/freddyboucher/gwt/oauth2/client/AuthImpl.java
@@ -18,10 +18,13 @@ package io.github.freddyboucher.gwt.oauth2.client;
 
 import com.google.gwt.core.client.Callback;
 import com.google.gwt.core.client.Duration;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
 import com.google.gwt.storage.client.Storage;
 import elemental2.dom.DomGlobal;
+import elemental2.dom.Event;
+import elemental2.dom.EventListener;import elemental2.dom.MessageEvent;
 import elemental2.dom.Window;
 import java.util.Map;
 
@@ -39,6 +42,19 @@ class AuthImpl extends Auth {
   AuthImpl() {
     super(Storage.isLocalStorageSupported() ? new TokenStoreImpl() : new CookieStoreImpl(),
         () -> Duration.currentTimeMillis(), Scheduler.get());
+    EventListener listener = (evt) -> {
+      if (evt == null || !(evt instanceof MessageEvent)) {
+        return;
+      }
+      @SuppressWarnings("rawtypes")
+      MessageEvent messageEvent = (MessageEvent) evt;
+      String data = String.valueOf(messageEvent.data);
+      String origin = messageEvent.origin;
+      DomGlobal.console.info(evt);
+      DomGlobal.console.info(data);
+      DomGlobal.console.info(origin);
+    };
+    DomGlobal.window.addEventListener("message", listener);
   }
 
   /**

--- a/gwt-oauth2/src/main/resources/io/github/freddyboucher/gwt/oauth2/resources/oauthWindow.html
+++ b/gwt-oauth2/src/main/resources/io/github/freddyboucher/gwt/oauth2/resources/oauthWindow.html
@@ -8,11 +8,11 @@
 </head>
 <body>
 <script type="text/javascript">
-  if (window.opener && window.opener.gwtOAuth2 && window.opener.gwtOAuth2.__doLogin) {
+  if (window.opener) {
     if (location.hash.length !== 0) {
-      window.opener.gwtOAuth2.__doLogin(location.hash);
+      window.opener.postMessage(location.hash, location.url);
     } else {
-      window.opener.gwtOAuth2.__doLogin(location.search);
+    	window.opener.postMessage(location.search, location.url);
     }
   } else {
     document.body.innerText =

--- a/gwt-oauth2/src/main/resources/io/github/freddyboucher/gwt/oauth2/resources/oauthWindow.html
+++ b/gwt-oauth2/src/main/resources/io/github/freddyboucher/gwt/oauth2/resources/oauthWindow.html
@@ -14,6 +14,7 @@
     } else {
     	window.opener.postMessage(location.search, location.url);
     }
+    window.close();
   } else {
     document.body.innerText =
         "Your browser seems to be stopping this window from communicating with the main window.";

--- a/gwt-oauth2/src/main/resources/io/github/freddyboucher/gwt/oauth2/resources/oauthWindow.html
+++ b/gwt-oauth2/src/main/resources/io/github/freddyboucher/gwt/oauth2/resources/oauthWindow.html
@@ -14,7 +14,7 @@
     } else {
     	window.opener.postMessage(location.search, location.url);
     }
-    window.close();
+    //window.close();
   } else {
     document.body.innerText =
         "Your browser seems to be stopping this window from communicating with the main window.";

--- a/gwt-oauth2/src/main/resources/io/github/freddyboucher/gwt/oauth2/resources/oauthWindow.html
+++ b/gwt-oauth2/src/main/resources/io/github/freddyboucher/gwt/oauth2/resources/oauthWindow.html
@@ -14,7 +14,6 @@
     } else {
     	window.opener.postMessage(location.search, location.url);
     }
-    //window.close();
   } else {
     document.body.innerText =
         "Your browser seems to be stopping this window from communicating with the main window.";


### PR DESCRIPTION
Use "window.postMessage" instead of JSInteropt exported hook.